### PR TITLE
Add support for Handout CNAME in properties

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -18,16 +18,31 @@ resource "akamai_gtm_data_center" "property_test_dc1" {
 }
 
 resource "akamai_gtm_data_center" "property_test_dc2" {
-  name      = "property_test_dc2"
-  domain    = "${akamai_gtm_domain.property_test_domain.name}"
-  country   = "IS"
-  continent = "EU"
-  city      = "Snæfellsjökull"
-  longitude = -23.776
-  latitude  = 64.808
+  name                   = "property_test_dc2"
+  domain                 = "${akamai_gtm_domain.property_test_domain.name}"
+  country                = "IS"
+  continent              = "EU"
+  city                   = "Snæfellsjökull"
+  longitude              = -23.776
+  latitude               = 64.808
 
   depends_on = [
     "akamai_gtm_data_center.property_test_dc1",
+  ]
+}
+
+resource "akamai_gtm_data_center" "property_test_dc3" {
+  name                   = "property_test_dc3"
+  domain                 = "${akamai_gtm_domain.property_test_domain.name}"
+  country                = "US"
+  continent              = "NA"
+  city                   = "Philadelphia"
+  longitude              = -75.167
+  latitude               = 39.95
+  cloud_server_targeting = true
+
+  depends_on = [
+    "akamai_gtm_data_center.property_test_dc2",
   ]
 }
 
@@ -79,12 +94,20 @@ resource "akamai_gtm_property" "test_property" {
   traffic_target {
     enabled        = true
     data_center_id = "${akamai_gtm_data_center.property_test_dc2.id}"
-    weight         = 50.0
+    weight         = 25.0
     name           = "${akamai_gtm_data_center.property_test_dc2.name}"
+    handout_cname  = "www.google.com"
+  }
 
-    servers = [
-      "1.2.3.6",
-      "1.2.3.7",
-    ]
+  traffic_target {
+    enabled        = true
+    data_center_id = "${akamai_gtm_data_center.property_test_dc3.id}"
+    weight         = 25.0
+    name           = "${akamai_gtm_data_center.property_test_dc3.name}"
+    handout_cname  = "www.comcast.com"
+
+    # specifying `servers` enables liveness tests for `handout_cname` and is
+    # required in conjunction with `cloud_server_targeting` on data centers.
+    servers = ["www.comcast.com"]
   }
 }

--- a/resource_gtm_property.go
+++ b/resource_gtm_property.go
@@ -192,11 +192,15 @@ func resourceAkamaiGTMProperty() *schema.Resource {
 						},
 						"servers": &schema.Schema{
 							Type:     schema.TypeSet,
-							Required: true,
+							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set: func(v interface{}) int {
 								return hashcode.String(v.(string))
 							},
+						},
+						"handout_cname": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -299,6 +303,7 @@ func trafficTargets(d *schema.ResourceData) []edgegrid.TrafficTarget {
 			Enabled:      d.Get(prefix + ".enabled").(bool),
 			Servers:      stringSetToStringSlice(d.Get(prefix + ".servers").(*schema.Set)),
 			DataCenterID: d.Get(prefix + ".data_center_id").(int),
+			HandoutCname: d.Get(prefix + ".handout_cname").(string),
 		})
 	}
 

--- a/resource_gtm_property_test.go
+++ b/resource_gtm_property_test.go
@@ -102,6 +102,20 @@ resource "akamai_gtm_data_center" "property_test_dc2" {
 	]
 }
 
+resource "akamai_gtm_data_center" "property_test_dc3" {
+	name = "property_test_dc3"
+	domain = "${var.test_domain}"
+	country = "US"
+	continent = "NA"
+	city = "Philadelphia"
+	longitude = -23.776
+	latitude = 64.808
+	cloud_server_targeting = true
+	depends_on = [
+		"akamai_gtm_data_center.property_test_dc2"
+	]
+}
+
 resource "akamai_gtm_property" "test_property" {
 	cname = "example.com"
 	domain = "${var.test_domain}"
@@ -122,18 +136,18 @@ resource "akamai_gtm_property" "test_property" {
 	stickiness_bonus_percentage = 50
 	stickiness_bonus_constant = 0
 	use_computed_targets = false
-  liveness_test {
-    name = "terraform-provider-akamai automated acceptance tests"
-    test_object = "/status"
-    test_object_protocol = "HTTP"
-    test_interval = 60
-    disable_nonstandard_port_warning = false
-    http_error_4xx = true
-    http_error_3xx = true
-    http_error_5xx = true
-    test_object_port = 80
-    test_timeout = 25
-  }
+	liveness_test {
+		name = "terraform-provider-akamai automated acceptance tests"
+		test_object = "/status"
+		test_object_protocol = "HTTP"
+		test_interval = 60
+		disable_nonstandard_port_warning = false
+		http_error_4xx = true
+		http_error_3xx = true
+		http_error_5xx = true
+		test_object_port = 80
+		test_timeout = 25
+	}
 	traffic_target {
 		enabled = true
 		data_center_id = "${akamai_gtm_data_center.property_test_dc1.id}"
@@ -147,12 +161,17 @@ resource "akamai_gtm_property" "test_property" {
 	traffic_target {
 		enabled = true
 		data_center_id = "${akamai_gtm_data_center.property_test_dc2.id}"
-		weight = 50.0
+		weight = 25.0
 		name = "${akamai_gtm_data_center.property_test_dc2.name}"
-		servers = [
-			"1.2.3.6",
-			"1.2.3.7"
-		]
+		handout_cname = "www.google.com"
+	}
+	traffic_target {
+		enabled = true
+		data_center_id = "${akamai_gtm_data_center.property_test_dc3.id}"
+		weight = 25.0
+		name = "${akamai_gtm_data_center.property_test_dc3.name}"
+		handout_cname = "www.comcast.com"
+		servers = ["www.comcast.com"]
 	}
 }
 `


### PR DESCRIPTION
This commit aims to add support for Handout CNAME in conjunction with Cloud Server Targeting. This is Akamai's recommended configuration for dynamic traffic targets such as AWS Elastic Load Balancers.